### PR TITLE
fix bug with config directive not being added to its own line

### DIFF
--- a/scripts/osx/install-dnsmasq.sh
+++ b/scripts/osx/install-dnsmasq.sh
@@ -36,7 +36,7 @@ configureDnsmasq() {
 
 	else
 		cp /usr/local/opt/dnsmasq/dnsmasq.conf.example /usr/local/etc/dnsmasq.conf
-		echo "address=/.dsdev/33.33.33.77" >> /usr/local/etc/dnsmasq.conf
+		echo "\\naddress=/.dsdev/33.33.33.77" >> /usr/local/etc/dnsmasq.conf
 	fi
 
 }


### PR DESCRIPTION
Before this PR, I was getting the following in my `/usr/local/etc/dnsmasq.conf`:

```bash
...
#conf-dir=/etc/dnsmasq.d/*.confaddress=/.dsdev/33.33.33.77
```

This PR solves this by adding a newline, causing the file to read:

```bash
...
#conf-dir=/etc/dnsmasq.d/*.conf
address=/.dsdev/33.33.33.77
```